### PR TITLE
bug/timeout into main

### DIFF
--- a/Keycloak.js
+++ b/Keycloak.js
@@ -150,6 +150,15 @@ class Keycloak {
         });
       }
     };
+    xhr.ontimeout = function () {
+      if (xhr.responseText) {
+        self.errCallback(JSON.parse(xhr.responseText));
+      } else {
+        self.errCallback({
+          error: "Unable to fetch the token due to a Network Timeout Error",
+        });
+      }
+    };
     xhr.send(urlencodeFormData(formData));
   }
 


### PR DESCRIPTION
Fixes issue where network request can timeout and silently error out the auth process. Examples scenario: User pulls card out and a refresh request happens. The request will time out but the error will not be picked up by the .onerror callback.